### PR TITLE
Update playback state when nowPlayingItemDidChange

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,6 +44,7 @@ function connectws() {
 				// Song changes
 				case ("playbackStatus.nowPlayingItemDidChange"):
 					UpdateSongInfo(data);
+					UpdatePlaybackState({ state: "playing" });
 					break;
 
 				// Progress bar moves

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ function connectws() {
 				// Song changes
 				case ("playbackStatus.nowPlayingItemDidChange"):
 					UpdateSongInfo(data);
-					UpdatePlaybackState({ state: "playing" });
+					UpdatePlaybackState({ attributes: data, state: "playing" });
 					break;
 
 				// Progress bar moves


### PR DESCRIPTION
According to a comment on Discord (https://discord.com/channels/157891598867234817/1381714110726672486/1381714110726672486) Cider 3.0 no longer sends `playbackStatus.playbackStateDidChange` when auto advancing to the next song. Only `playbackStatus.nowPlayingItemDidChange` is sent, so this PR adds a call to `UpdatePlaybackState` when receiving the event. This fixes #1 